### PR TITLE
feat: implement date-time-specific log files with milliseconds

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 )
 
 var (
@@ -167,9 +168,16 @@ func canCreateLogFile(logFilePath string) bool {
 // getDefaultLogPath returns the default log path if none is provided
 func getDefaultLogPath(logFilePath string) string {
 	if logFilePath == "" {
-		return "./logs/whaletui.log"
+		return generateDateSpecificLogPath()
 	}
 	return logFilePath
+}
+
+// generateDateSpecificLogPath generates a log file path with the current date and time
+func generateDateSpecificLogPath() string {
+	now := time.Now()
+	dateTimeStr := now.Format("2006-01-02_15-04-05.000")
+	return fmt.Sprintf("./logs/whaletui-%s.log", dateTimeStr)
 }
 
 // setupLogFile sets up the global log file variables
@@ -211,14 +219,8 @@ func createLogsDirectory(logFilePath string) error {
 // openLogFile opens the log file for writing
 func openLogFile(logFilePath string) (*os.File, error) {
 	const fileMode = 0o600
-	const defaultLogPath = "./logs/whaletui.log"
 
-	// Use a constant path to avoid gosec warning
-	if logFilePath == defaultLogPath {
-		return os.OpenFile(defaultLogPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, fileMode)
-	}
-
-	// For non-default paths, validate the path to prevent directory traversal
+	// Validate the path to prevent directory traversal
 	if !isValidLogPath(logFilePath) {
 		return nil, fmt.Errorf("invalid log file path: %s", logFilePath)
 	}

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"os"
+	"regexp"
 	"testing"
 )
 
@@ -90,9 +91,24 @@ func TestDefaultLogPath(t *testing.T) {
 	// Test that default path is used when empty string is provided
 	SetLevelWithPath("DEBUG", "")
 
-	// Verify default log file exists
-	defaultPath := "./logs/whaletui.log"
-	if _, err := os.Stat(defaultPath); os.IsNotExist(err) {
+	// Verify default log file exists (now with date-time format)
+	logPath := GetLogFilePath()
+	if logPath == "" {
+		t.Fatal("Log file path should be set")
+	}
+
+	// Check that the log file path follows the expected date-time format
+	expectedPattern := `^\./logs/whaletui-\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}\.\d{3}\.log$`
+	matched, err := regexp.MatchString(expectedPattern, logPath)
+	if err != nil {
+		t.Fatalf("Error matching pattern: %v", err)
+	}
+	if !matched {
+		t.Fatalf("Log file path should match date-time format, got: %s", logPath)
+	}
+
+	// Verify the log file actually exists
+	if _, err := os.Stat(logPath); os.IsNotExist(err) {
 		t.Fatal("Default log file should be created")
 	}
 


### PR DESCRIPTION
This PR implements date-time-specific log file naming with millisecond precision for better log organization and debugging. Log files will now be created with names like: whaletui-2025-09-14_17-45-41.575.log